### PR TITLE
Fix transform usage and workflow newline

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,4 +36,4 @@ jobs:
           
       - name: deploy to github pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@v4

--- a/script.js
+++ b/script.js
@@ -724,9 +724,10 @@ function updateMapTransform() {
     const svg = document.getElementById('map');
     // ensure consistent panning regardless of zoom by translating in unscaled units
     svg.style.transformOrigin = '0 0';
+    // apply panning before scaling for consistent interaction
     const translateX = currentPanX;
     const translateY = currentPanY;
-    svg.style.transform = `translate(${currentPanX}px, ${currentPanY}px) scale(${currentZoom})`;
+    svg.style.transform = `translate(${translateX}px, ${translateY}px) scale(${currentZoom})`;
 }
 
 // make functions globally available


### PR DESCRIPTION
## Summary
- apply panning variables when transforming the map for clarity
- add trailing newline to GitHub Actions workflow

## Testing
- `node -e "require('./data/airports.js')"`


------
https://chatgpt.com/codex/tasks/task_e_688a19ae25dc8324831ed699b7a30f1b